### PR TITLE
Add simple React app

### DIFF
--- a/Entities/Project.js
+++ b/Entities/Project.js
@@ -1,0 +1,16 @@
+import data from './Project.json' assert { type: 'json' };
+
+const projects = data.projects;
+
+export const Project = {
+  async list() {
+    return projects;
+  },
+  async filter(criteria) {
+    let result = projects;
+    if (criteria && criteria.featured !== undefined) {
+      result = result.filter(p => p.featured === criteria.featured);
+    }
+    return result;
+  }
+};

--- a/Pages/Contact.js
+++ b/Pages/Contact.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { motion } from "framer-motion";
 import { Mail, MapPin, Send } from "lucide-react";
-import { SendEmail } from "@/integrations/Core";
+import { SendEmail } from "../integrations/Core";
 
 export default function Contact() {
   const [formData, setFormData] = useState({ name: "", email: "", message: "" });

--- a/Pages/Portfolio.js
+++ b/Pages/Portfolio.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from "react";
-import { Project } from "@/entities/Project";
+import { Project } from "../Entities/Project";
 import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
-import { createPageUrl } from "@/utils";
+import { createPageUrl } from "../utils";
 import { ArrowRight } from "lucide-react";
 
 export default function Portfolio() {

--- a/Pages/TheSpace.js
+++ b/Pages/TheSpace.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Project } from "@/entities/Project";
+import { Project } from "../Entities/Project";
 import { motion, AnimatePresence } from "framer-motion";
 
 export default function TheSpace() {

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BREWHAUS</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet" />
+</head>
+<body class="bg-[#FFFCF2] text-[#252422]">
+  <div id="root"></div>
+  <script type="module" src="./index.js"></script>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Layout from './layout';
+import Portfolio from './Pages/Portfolio';
+import TheSpace from './Pages/TheSpace';
+import DesignStory from './Pages/DesignStory';
+import SiteAnalysis from './Pages/SiteAnalysis';
+import Contact from './Pages/Contact';
+
+const root = createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <Layout>
+        <Routes>
+          <Route index element={<Portfolio />} />
+          <Route path="the-space" element={<TheSpace />} />
+          <Route path="design-story" element={<DesignStory />} />
+          <Route path="site-analysis" element={<SiteAnalysis />} />
+          <Route path="contact" element={<Contact />} />
+        </Routes>
+      </Layout>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/integrations/Core.js
+++ b/integrations/Core.js
@@ -1,0 +1,4 @@
+export async function SendEmail({ to, subject, body }) {
+  console.log('Mock send email:', { to, subject, body });
+  return true;
+}

--- a/layout.js
+++ b/layout.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { createPageUrl } from "@/utils";
+import { createPageUrl } from "./utils";
 import { Menu, X } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,4 @@
+export function createPageUrl(page) {
+  if (page === 'Portfolio') return '/';
+  return '/' + page.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+}


### PR DESCRIPTION
## Summary
- wire up minimal React app with router and layout
- provide mock utilities and data layer
- adapt existing pages to new import paths
- add simple index.html as entry point

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d66a05520833186c3b3e3f43ab06b